### PR TITLE
Update xata links

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [neon.tech](https://neon.tech) *     | 500 MB     | 0.25 – 2 | 1 GB   | [PITR for 24 hours](https://neon.tech/docs/manage/backups)                                                                                                                              |
 | [rapidapp.io](https://rapidapp.io/)  | 20 MB      | N/A      | N/A    | ❌                                                                                                                                                                                       |
 | [supabase.com](https://supabase.com) | 500 MB     | N/A      | 500 MB | ❌                                                                                                                                                                                       |
-| [xata.io](https://xata.io/)          | 15 GB      | N/A      | N/A    | [Daily backups. Restoration is available once per month](https://xata.io/docs/concepts/pricing#daily-backups)                                                                          |
+| [xata.io](https://lite.xata.io/)     | 15 GB      | N/A      | N/A    | [Daily backups. Restoration is available once per month](https://xata.io/docs/concepts/pricing#daily-backups)                                                                          |
 
 \* **Neon** has auto-scaling enabled by default. It's recommended to disable it to avoid exceeding the 190 compute hours/month quota.
 
@@ -44,7 +44,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [neon.tech](https://neon.tech)       | 5 GB                                                                                                                                                     | 190 compute hours      | [Auto pause after 5 minutes of inactivity (cannot be disabled on free plan)](https://neon.tech/docs/guides/scale-to-zero-guide).                                                      |
 | [rapidapp.io](https://rapidapp.io/)  | —                                                                                                                                                        | —                      | No pause                                                                                                                                                                              |
 | [supabase.com](https://supabase.com) | 5 GB                                                                                                                                                     | —                      | [May pause after 7 days of low activity](https://supabase.com/docs/guides/deployment/going-into-prod#availability).                                                                   |
-| [xata.io](https://xata.io/)          | [Concurrency limits](https://xata.io/docs/concepts/pricing#concurrency-limit), [Requests rate limits](https://xata.io/docs/concepts/pricing#rate-limit). | -                      | [Marked as inactive if there is no activity registered within 30 days](https://xata.io/docs/inactive-branches)                                                                        |
+| [xata.io](https://lite.xata.io/)     | [Concurrency limits](https://xata.io/docs/concepts/pricing#concurrency-limit), [Requests rate limits](https://xata.io/docs/concepts/pricing#rate-limit). | -                      | [Marked as inactive if there is no activity registered within 30 days](https://xata.io/docs/inactive-branches)                                                                        |
 
 ### 🌍 Regions & Registration
 
@@ -56,7 +56,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [neon.tech](https://neon.tech)       | Email, Google, GitHub, Microsoft | US, Canada, Europe, Asia                                                        |
 | [rapidapp.io](https://rapidapp.io/)  | GitHub                           | N/A                                                                             |
 | [supabase.com](https://supabase.com) | Email, GitHub                    | US, Europe, Asia                                                                |
-| [xata.io](https://xata.io/)          | Email, Google, GitHub            | [US, Europe, Australia](https://xata.io/docs/getting-started/available-regions) |
+| [xata.io](https://lite.xata.io/)     | Email, Google, GitHub            | [US, Europe, Australia](https://xata.io/docs/getting-started/available-regions) |
 
 \* **Filess** automatically selects a region based on your location. In my case, it was Nuremberg with no way to change the region manually.
 


### PR DESCRIPTION
According to the [xata.io FAQ section](https://xata.io/pricing) (located at the end of the pricing page), there is no free tier. It mentions, however, that Xata Lite is free. 

In the [README](https://github.com/alexeyfv/awesome-free-postgres/blob/3c465784e2914110485608fabfc508e66c719930/README.md), there are three instances where the xata.io hyperlink is linked to the [Xata Platform](https://xata.io) (which does not have a free tier), when they should point to [Xata Lite](https://lite.xata.io) (which has the free tier). Below are the three instances:

**Line 31:**
https://github.com/alexeyfv/awesome-free-postgres/blob/3c465784e2914110485608fabfc508e66c719930/README.md?plain=1#L31
**Line 47:**
https://github.com/alexeyfv/awesome-free-postgres/blob/3c465784e2914110485608fabfc508e66c719930/README.md?plain=1#L47
**Line 59:**
https://github.com/alexeyfv/awesome-free-postgres/blob/3c465784e2914110485608fabfc508e66c719930/README.md?plain=1#L59

This PR replaces all instances of `https://xata.io` with `https://lite.xata.io` in hopes to assuage any confusion.

All other hyperlinks correctly link to Xata Lite documentation, despite the `lite` subdomain missing from the URLs.