### PR TITLE
Add miget.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [nhost.io](https://nhost.io/)                                                                                    | 1 GB       | 0.5 CPU | 256 MiB | ❌                                                                                                                                                                                      |
 | [tigerdata.com](https://www.tigerdata.com/blog/introducing-agentic-postgres-free-plan-experiment-ai-on-postgres) | 2 x 750 MB | N/A     | N/A     | 24h PITR                                                                                                                                                                                |
 | [rivestack.io](https://docs.rivestack.io/pricing) \*\*                                                           | 2 GB       | N/A     | N/A     | ❌                                                                                                                                                                                      |
-| [miget.com](https://miget.com/plans) \*\*\*                                                                      | 1 GB       | 0.1     | 256 MiB | ❌                                                                                                                                                                                      |
+| [miget.com](https://miget.com/blog/free-postgresql-hosting-public-access) \*\*\*                                                                      | 1 GB       | 0.1     | 256 MiB | ❌                                                                                                                                                                                      |
 
 \*\* **Rivestack** comes with the [pgvector](https://github.com/pgvector/pgvector) extension pre-installed on all databases, including the free tier.
 
-\*\*\* **Miget's** free tier is a single 0.1 CPU / 256 MiB / 1 GB resource shared by every workload on it, so the database gets the whole quota only when nothing else runs there. [pgvector](https://github.com/pgvector/pgvector) is included, and public IPv4/IPv6 access is optional.
+\*\*\* **Miget's** free tier is a single 0.1 CPU / 256 MiB / 1 GB resource shared by every workload on it, so the database gets the whole quota only when nothing else runs there. [pgvector](https://github.com/pgvector/pgvector), PostGIS and TimescaleDB are among the [extensions available on every database](https://docs.miget.com/databases/postgresql#postgresql-extensions), and public IPv4/IPv6 access is optional.
 
 ### 🛑 Limits
 
@@ -50,7 +50,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [nhost.io](https://nhost.io/)                                                                                    | 5 GB egress                | 1 project, 1 memeber      | [Paused after 1 week inactivity](https://nhost.io/pricing)                                                                                         |
 | [tigerdata.com](https://www.tigerdata.com/blog/introducing-agentic-postgres-free-plan-experiment-ai-on-postgres) | —                          | —                         | No pause                                                                                                                                           |
 | [rivestack.io](https://rivestack.io)                                                                             | —                          | 1 database, 5 connections | No pause                                                                                                                                           |
-| [miget.com](https://miget.com/plans)                                                                             | —                          | 1 resource, personal accounts only | No pause                                                                                                                          |
+| [miget.com](https://miget.com/blog/free-postgresql-hosting-public-access)                                                                             | —                          | 1 resource, personal accounts only | No pause                                                                                                                          |
 
 ### 🌍 Regions & Registration
 
@@ -64,7 +64,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [nhost.io](https://nhost.io/)                                                                                | GitHub, Email                    | US, Europe, Asia, South America |
 | [tigerdata.com](https://tigerdata.com/blog/introducing-agentic-postgres-free-plan-experiment-ai-on-postgres) | Google, Email                    | US                              |
 | [rivestack.io](https://rivestack.io)                                                                         | Email, Google, GitHub            | US, Europe                      |
-| [miget.com](https://miget.com/plans)                                                                         | Email, Google, GitHub            | US, Europe                      |
+| [miget.com](https://miget.com/blog/free-postgresql-hosting-public-access)                                                                         | Email, Google, GitHub            | US, Europe                      |
 
 \* **Filess** automatically selects a region based on your location. In my case, it was Nuremberg with no way to change the region manually.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 
 \*\* **Rivestack** comes with the [pgvector](https://github.com/pgvector/pgvector) extension pre-installed on all databases, including the free tier.
 
-\*\*\* **Miget's** free tier is a single 0.1 CPU / 256 MiB / 1 GB resource shared by every workload on it, so the database gets the whole quota only when nothing else runs there. [pgvector](https://github.com/pgvector/pgvector), PostGIS and TimescaleDB are among the [extensions available on every database](https://docs.miget.com/databases/postgresql#postgresql-extensions), and public IPv4/IPv6 access is optional.
+\*\*\* **Miget's** free tier is a single 0.1 CPU / 256 MiB / 1 GB resource shared by every workload on it, so the database gets the whole quota only when nothing else runs there. [pgvector](https://github.com/pgvector/pgvector), PostGIS, TimescaleDB and pg_cron are among the [extensions available on every database](https://docs.miget.com/databases/postgresql#postgresql-extensions), including ones that normally need a server restart to enable. Public IPv4/IPv6 access is optional.
 
 ### 🛑 Limits
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [nhost.io](https://nhost.io/)                                                                                    | 1 GB       | 0.5 CPU | 256 MiB | ❌                                                                                                                                                                                      |
 | [tigerdata.com](https://www.tigerdata.com/blog/introducing-agentic-postgres-free-plan-experiment-ai-on-postgres) | 2 x 750 MB | N/A     | N/A     | 24h PITR                                                                                                                                                                                |
 | [rivestack.io](https://docs.rivestack.io/pricing) \*\*                                                           | 2 GB       | N/A     | N/A     | ❌                                                                                                                                                                                      |
+| [miget.com](https://miget.com/plans) \*\*\*                                                                      | 1 GB       | 0.1     | 256 MiB | ❌                                                                                                                                                                                      |
 
 \*\* **Rivestack** comes with the [pgvector](https://github.com/pgvector/pgvector) extension pre-installed on all databases, including the free tier.
+
+\*\*\* **Miget's** free tier is a single 0.1 CPU / 256 MiB / 1 GB resource shared by every workload on it, so the database gets the whole quota only when nothing else runs there. [pgvector](https://github.com/pgvector/pgvector) is included, and public IPv4/IPv6 access is optional.
 
 ### 🛑 Limits
 
@@ -47,6 +50,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [nhost.io](https://nhost.io/)                                                                                    | 5 GB egress                | 1 project, 1 memeber      | [Paused after 1 week inactivity](https://nhost.io/pricing)                                                                                         |
 | [tigerdata.com](https://www.tigerdata.com/blog/introducing-agentic-postgres-free-plan-experiment-ai-on-postgres) | —                          | —                         | No pause                                                                                                                                           |
 | [rivestack.io](https://rivestack.io)                                                                             | —                          | 1 database, 5 connections | No pause                                                                                                                                           |
+| [miget.com](https://miget.com/plans)                                                                             | —                          | 1 resource, personal accounts only | No pause                                                                                                                          |
 
 ### 🌍 Regions & Registration
 
@@ -60,6 +64,7 @@ To be included in this list, a PostgreSQL provider must meet all of the followin
 | [nhost.io](https://nhost.io/)                                                                                | GitHub, Email                    | US, Europe, Asia, South America |
 | [tigerdata.com](https://tigerdata.com/blog/introducing-agentic-postgres-free-plan-experiment-ai-on-postgres) | Google, Email                    | US                              |
 | [rivestack.io](https://rivestack.io)                                                                         | Email, Google, GitHub            | US, Europe                      |
+| [miget.com](https://miget.com/plans)                                                                         | Email, Google, GitHub            | US, Europe                      |
 
 \* **Filess** automatically selects a region based on your location. In my case, it was Nuremberg with no way to change the region manually.
 


### PR DESCRIPTION
Adds Miget to the three comparison tables.

Disclosure: I work on Miget, so please check the numbers rather than take my word for them.

**Criteria**

- Free registration, no credit card.
- No time limit. The free resource is permanent, not a trial, and nothing is deleted after a fixed period.

**Numbers**

| | |
|---|---|
| Space / CPU / RAM | 1 GB / 0.1 / 256 MiB |
| Backups | none on the free tier |
| Pause | none. Apps on the free tier sleep after 30 minutes idle; databases do not |
| Registration | Email, Google, GitHub |
| Locations | US, Europe |

The footnote spells out the one thing that could otherwise mislead: the 0.1 CPU / 256 MiB / 1 GB is the whole free resource, shared with any app you also run on it. A database gets the full quota only when it is the only workload there.

Extensions are listed at https://docs.miget.com/databases/postgresql#postgresql-extensions. pgvector, PostGIS and TimescaleDB are there, and the ones that normally need `shared_preload_libraries` plus a restart (pg_cron, pgaudit, pg_net, anon and others) are preloaded, so `CREATE EXTENSION` is the only step.

Happy to adjust the wording, move the row, or drop it if it does not fit the list.